### PR TITLE
Add local LLM integration

### DIFF
--- a/Maroik.AI/Dockerfile
+++ b/Maroik.AI/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update && apt-get install -y libpq-dev libicu-dev && apt-get clean &
 WORKDIR /app
 
 COPY ["Maroik.AI/requirements.txt", "Maroik.AI/"]
-RUN pip install --no-cache-dir -r /app/Maroik.AI/requirements.txt
+RUN pip install --no-cache-dir -r /app/Maroik.AI/requirements.txt \
+    --extra-index-url https://download.pytorch.org/whl/cpu
 
 COPY ./Maroik.AI/ /app/
 

--- a/Maroik.AI/main.py
+++ b/Maroik.AI/main.py
@@ -1,8 +1,16 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+import os
 import train_model
+from transformers import AutoTokenizer, AutoModelForCausalLM
+import torch
 
 app = FastAPI()
+
+# Load local LLM model using environment variable
+model_path = os.environ.get("LOCAL_LLM_MODEL_PATH", "./models")
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+model = AutoModelForCausalLM.from_pretrained(model_path)
 
 class DateRange(BaseModel):
     start_date: str
@@ -11,6 +19,10 @@ class DateRange(BaseModel):
 class UserInfo(BaseModel):
     name: str
     age: int
+
+class LLMRequest(BaseModel):
+    prompt: str
+    max_tokens: int = 50
 
 @app.post("/train_model/")
 def train_and_predict(data: DateRange):
@@ -35,3 +47,11 @@ def hellowithparameter(user: UserInfo):
     return {
         "message": f"Hello, {user.name}. You are {user.age} years old."
     }
+
+@app.post("/llm/generate")
+def generate_text(request: LLMRequest):
+    inputs = tokenizer(request.prompt, return_tensors="pt")
+    with torch.no_grad():
+        outputs = model.generate(**inputs, max_new_tokens=request.max_tokens)
+    text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    return {"generated_text": text}

--- a/Maroik.AI/requirements.txt
+++ b/Maroik.AI/requirements.txt
@@ -4,3 +4,5 @@ numpy==1.22
 pandas==1.3.5
 psycopg2-binary==2.9.5
 scikit-learn==1.5.0
+torch==2.1.2
+transformers==4.52.4

--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ Maroik/
 2. Start debug mode with docker-compose.debug.yml
 3. Configure mail settings in appsettings files
 
+## Local LLM Setup
+The `maroik.ai` container can load a HuggingFace compatible model from the host.
+Place your model files in a directory on the host and mount it into the container
+through `docker-compose.yml`:
+
+```yaml
+maroik.ai:
+  environment:
+    - LOCAL_LLM_MODEL_PATH=/models
+  volumes:
+    - ./local_llm:/models:ro
+```
+
+The application exposes a `/llm/generate` endpoint that accepts a prompt and
+returns the generated text using the local model.
+
 ## Screenshots
 
 ### Login

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,8 +106,10 @@ services:
           - "8000"
         environment:
           - DBPASSWORD=qwer12!@#
+          - LOCAL_LLM_MODEL_PATH=/models
         volumes:
           - ./Maroik.AI:/app/
+          - ./local_llm:/models:ro
         depends_on:
           - postgresql
         restart: always


### PR DESCRIPTION
## Summary
- add torch & transformers to AI requirements
- update Dockerfile to install from CPU wheel index
- load HuggingFace models in `main.py` and expose `/llm/generate`
- mount model volume in docker-compose and add `LOCAL_LLM_MODEL_PATH`
- document local model usage

## Testing
- `python -m py_compile Maroik.AI/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852b89f35008328a77ba7324954f034